### PR TITLE
Merge catasaurus/markdown-cheatsheet into atapas/markdown-cheatsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,11 +583,14 @@ RL variant
 You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
 ```
 [text that you want to display](name-of-section-link)
+ 
+[Make sure to space items with a line](some-section-link)
 ```
 Then, in the section that you want to link to just put `<a id="name-of-section-link><\a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
 
 **Output:**
 [This is the first item in a table of contents](section-one)
+ 
 [This is the second item in a table of contents](section-two)
 
 <a id="section-one"></a>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 22. [DropDown](#dropdown)
 23. [Diagrams](#diagrams)
 24. [FootNote](#footnote)
+25. [Table of Contents](#table-of-contents)
 
 Many Thanks to all the `Stargazers` who has supported this project with stars(⭐)
 
@@ -600,3 +601,22 @@ Here's a simple footnote,[^1] and here's a longer one.[^bignote]
 [^1]: This is the first footnote.
 
 [^bignote]: Here's one with multiple paragraphs and code.
+
+<a id="table-of-contents"><\a>
+## Table of Contents
+
+You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
+```
+[text that you want to display](name-of-section-link)
+```
+Then, in the section that you want to link to just put `<a id="name-of-section-link><\a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
+
+**Output:**
+[This is the first item in a table of contents](section-one)
+[This is the second item in a table of contents](section-two)
+
+<a id="section-one"><\a>
+## This is the first item in a table of contents
+
+<a id="section-two"><\a>
+## This is the second item in a table of contents

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 22. [DropDown](#dropdown)
 23. [Diagrams](#diagrams)
 24. [FootNote](#footnote)
-25. [Table of Contents](#table-of-contents)
+25. [Table of Contents](#toc)
 
 Many Thanks to all the `Stargazers` who has supported this project with stars(⭐)
 
@@ -577,6 +577,25 @@ RL variant
             D-->E;
 ```
 
+<a id="toc"><\a>
+## Table of Contents
+
+You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
+```
+[text that you want to display](name-of-section-link)
+```
+Then, in the section that you want to link to just put `<a id="name-of-section-link><\a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
+
+**Output:**
+[This is the first item in a table of contents](section-one)
+[This is the second item in a table of contents](section-two)
+
+<a id="section-one"></a>
+## This is the first item in a table of contents
+
+<a id="section-two"></a>
+## This is the second item in a table of contents
+
 ## FootNote
 
 **Explanation:**
@@ -602,21 +621,3 @@ Here's a simple footnote,[^1] and here's a longer one.[^bignote]
 
 [^bignote]: Here's one with multiple paragraphs and code.
 
-<a id="table-of-contents"><\a>
-## Table of Contents
-
-You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
-```
-[text that you want to display](name-of-section-link)
-```
-Then, in the section that you want to link to just put `<a id="name-of-section-link><\a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
-
-**Output:**
-[This is the first item in a table of contents](section-one)
-[This is the second item in a table of contents](section-two)
-
-<a id="section-one"><\a>
-## This is the first item in a table of contents
-
-<a id="section-two"><\a>
-## This is the second item in a table of contents

--- a/README.md
+++ b/README.md
@@ -582,17 +582,17 @@ RL variant
 
 You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
 ```
-[text that you want to display](name-of-section-link)
+[text that you want to display](#name-of-section-link)
  
-[Make sure to space items with a line](some-section-link)
+[Make sure to space items with a line](#some-section-link)
 ```
 Then, in the section that you want to link to just put `<a id="name-of-section-link><\a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
 
 **Output:**
  
-[This is the first item in a table of contents](section-one)
+[This is the first item in a table of contents](#section-one)
  
-[This is the second item in a table of contents](section-two)
+[This is the second item in a table of contents](#section-two)
 
 <a id="section-one"><\a>
 ## This is the first item in a table of contents

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ Then, in the section that you want to link to, put `<a id="name-of-section-link>
  
 [text that you want to display](#name-of-section-link)
  
-[This is the second item in a table of contents](#section-two)
+[Make sure to space items with a line](#section-two)
 
 <a id="name-of-section-link"></a>
 ## Item one

--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ RL variant
 ## Table of Contents
 
 **Explanation**
+
 You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
 ```
 [text that you want to display](#name-of-section-link)

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ RL variant
 <a id="toc"></a>
 ## Table of Contents
 
-**Explanantion**
+**Explanation**
 You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
 ```
 [text that you want to display](#name-of-section-link)
@@ -589,8 +589,9 @@ You can create a table of contents just like the one at the start of this cheet 
 ```
 Then, in the section that you want to link to, put `<a id="name-of-section-link></a>`. Make sure that the text inside the parentheses in the table of contents item matches the id:
 ```
+<a id="name-of-section-link"></a>
 ## text that you want to display
-
+```
 **Output:**
  
 [text that you want to display](#name-of-section-link)

--- a/README.md
+++ b/README.md
@@ -589,14 +589,15 @@ You can create a table of contents just like the one at the start of this cheet 
 Then, in the section that you want to link to just put `<a id="name-of-section-link><\a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
 
 **Output:**
+ 
 [This is the first item in a table of contents](section-one)
  
 [This is the second item in a table of contents](section-two)
 
-<a id="section-one"></a>
+<a id="section-one"><\a>
 ## This is the first item in a table of contents
 
-<a id="section-two"></a>
+<a id="section-two"><\a>
 ## This is the second item in a table of contents
 
 ## FootNote

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ RL variant
             D-->E;
 ```
 
-<a id="toc"><\a>
+<a id="toc"></a>
 ## Table of Contents
 
 You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
@@ -586,7 +586,7 @@ You can create a table of contents just like the one at the start of this cheet 
  
 [Make sure to space items with a line](#some-section-link)
 ```
-Then, in the section that you want to link to just put `<a id="name-of-section-link><\a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
+Then, in the section that you want to link to just put `<a id="name-of-section-link></a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
 
 **Output:**
  
@@ -594,10 +594,10 @@ Then, in the section that you want to link to just put `<a id="name-of-section-l
  
 [This is the second item in a table of contents](#section-two)
 
-<a id="section-one"><\a>
+<a id="section-one"></a>
 ## This is the first item in a table of contents
 
-<a id="section-two"><\a>
+<a id="section-two"></a>
 ## This is the second item in a table of contents
 
 ## FootNote

--- a/README.md
+++ b/README.md
@@ -580,25 +580,28 @@ RL variant
 <a id="toc"></a>
 ## Table of Contents
 
+**Explanantion**
 You can create a table of contents just like the one at the start of this cheet sheet with the following syntax:
 ```
 [text that you want to display](#name-of-section-link)
  
-[Make sure to space items with a line](#some-section-link)
+[Make sure to space items with a line](#section-two)
 ```
-Then, in the section that you want to link to just put `<a id="name-of-section-link></a>`. Just make sure that the text inside the parentheses in the table of contents matches the id.
+Then, in the section that you want to link to, put `<a id="name-of-section-link></a>`. Make sure that the text inside the parentheses in the table of contents item matches the id:
+```
+## text that you want to display
 
 **Output:**
  
-[This is the first item in a table of contents](#section-one)
+[text that you want to display](#name-of-section-link)
  
 [This is the second item in a table of contents](#section-two)
 
-<a id="section-one"></a>
-## This is the first item in a table of contents
+<a id="name-of-section-link"></a>
+## Item one
 
 <a id="section-two"></a>
-## This is the second item in a table of contents
+## Item two
 
 ## FootNote
 


### PR DESCRIPTION
I added a tutorial on how to create a table of contents. This also included how to add sections throughout the markdown file and create links to those sections.  I checked if my changes to the markdown file had any affect on the section on how to create a footnote, which I made sure to leave at the bottom of the file.